### PR TITLE
Add GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,53 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Build site
+        run: yarn build
+
+      - name: Upload build output
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -7,3 +7,12 @@ This repository contains a Vite + React starter generated with Yarn. The app fea
 - `yarn dev` – Start the Vite development server.
 - `yarn build` – Create an optimized production build.
 - `yarn preview` – Preview the production build locally.
+
+## Deployment
+
+The project is ready to deploy to GitHub Pages via GitHub Actions:
+
+1. Push your changes to the `main` branch or trigger the `Deploy to GitHub Pages` workflow manually.
+2. In your repository settings, set **Pages** → **Build and deployment** → **Source** to **GitHub Actions** (only required once).
+
+The workflow installs dependencies with Yarn 4, builds the site, and publishes the `dist/` output using the official `deploy-pages` action. The Vite configuration automatically adjusts the base path so the app works both locally and when served from GitHub Pages.

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,6 +1,11 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
+const repository = process.env.GITHUB_REPOSITORY?.split('/')?.[1] ?? ''
+const isUserSite = repository.toLowerCase().endsWith('.github.io')
+const base = process.env.GITHUB_ACTIONS && repository && !isUserSite ? `/${repository}/` : '/'
+
 export default defineConfig({
   plugins: [react()],
+  base,
 })


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that builds the Vite app and publishes the dist output to GitHub Pages
- configure Vite to set the correct base path when running inside GitHub Actions so the site works from a subdirectory
- document how to trigger the deployment workflow and enable GitHub Pages in the repository settings

## Testing
- yarn --version *(fails in the execution environment: blocked from downloading yarn@4.5.1)*

------
https://chatgpt.com/codex/tasks/task_e_68cdbd7cc8b883248e554cbac5644177