### PR TITLE
Add game selection flow to arcade landing page

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,3 +1,5 @@
+import { useState } from 'react'
+
 import TicTacToe from './TicTacToe'
 import Snake from './Snake'
 
@@ -82,8 +84,13 @@ const listStyle = {
   padding: 0,
 }
 
-const gameCardStyle = {
+const listItemStyle = {
+  margin: 0,
+}
+
+const gameButtonStyle = {
   position: 'relative',
+  width: '100%',
   display: 'flex',
   flexDirection: 'column',
   gap: '1.2rem',
@@ -94,9 +101,15 @@ const gameCardStyle = {
   border: '1px solid rgba(255, 255, 255, 0.12)',
   boxShadow:
     'inset 0 0 35px rgba(255, 45, 149, 0.18), 0 12px 40px rgba(0, 0, 0, 0.45)',
+  color: '#f9f7ff',
+  cursor: 'pointer',
+  textAlign: 'left',
+  transition: 'transform 0.2s ease, box-shadow 0.2s ease',
+  font: 'inherit',
+  letterSpacing: 'inherit',
 }
 
-const gameTitleStyle = {
+const gameButtonTitleStyle = {
   fontSize: '1.1rem',
   letterSpacing: '0.16em',
   textTransform: 'uppercase',
@@ -108,6 +121,54 @@ const gameDescriptionStyle = {
   fontSize: '0.92rem',
   lineHeight: 1.7,
   color: 'rgba(235, 229, 255, 0.85)',
+}
+
+const activeGameContainerStyle = {
+  position: 'relative',
+  zIndex: 1,
+  borderRadius: '1.75rem',
+  padding: '2.5rem',
+  background: 'linear-gradient(145deg, rgba(20, 0, 55, 0.85), rgba(54, 0, 98, 0.65))',
+  boxShadow: 'inset 0 0 40px rgba(255, 45, 149, 0.35)',
+  border: '1px solid rgba(255, 255, 255, 0.12)',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '1.5rem',
+}
+
+const activeGameHeaderStyle = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '0.85rem',
+}
+
+const activeGameTitleStyle = {
+  fontSize: '1.4rem',
+  letterSpacing: '0.2em',
+  textTransform: 'uppercase',
+  textShadow: '0 0 14px rgba(255, 82, 190, 0.9)',
+}
+
+const backButtonStyle = {
+  alignSelf: 'flex-start',
+  padding: '0.75rem 1.5rem',
+  borderRadius: '999px',
+  border: '1px solid rgba(255, 255, 255, 0.22)',
+  background: 'rgba(15, 0, 45, 0.7)',
+  color: '#f9f7ff',
+  cursor: 'pointer',
+  fontFamily: '"Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
+  fontSize: '0.85rem',
+  letterSpacing: '0.18em',
+  textTransform: 'uppercase',
+}
+
+const gameAreaStyle = {
+  borderRadius: '1.25rem',
+  padding: '1.5rem',
+  background: 'rgba(5, 0, 28, 0.75)',
+  border: '1px solid rgba(255, 255, 255, 0.08)',
+  boxShadow: 'inset 0 0 28px rgba(255, 45, 149, 0.2)',
 }
 
 const footerStyle = {
@@ -138,6 +199,8 @@ const App = () => {
     },
   ]
 
+  const [activeGame, setActiveGame] = useState(null)
+
   return (
     <div style={containerStyle}>
       <div style={panelStyle}>
@@ -147,20 +210,38 @@ const App = () => {
           Plug in your headphones, turn up the synths, and get ready to cruise through neon
           dreams. This is your retro-wave hub for upcoming indie experiences.
         </p>
-        <section style={listContainerStyle}>
-          <h2 style={listTitleStyle}>Featured Games</h2>
-          <ul style={listStyle}>
-            {games.map((game) => (
-              <li key={game.title} style={gameCardStyle}>
-                <div>
-                  <h3 style={gameTitleStyle}>{game.title}</h3>
-                  <p style={gameDescriptionStyle}>{game.description}</p>
-                </div>
-                {game.component}
-              </li>
-            ))}
-          </ul>
-        </section>
+        {activeGame ? (
+          <section style={activeGameContainerStyle}>
+            <button onClick={() => setActiveGame(null)} style={backButtonStyle} type="button">
+              Back to Games
+            </button>
+            <div style={activeGameHeaderStyle}>
+              <h2 style={activeGameTitleStyle}>{activeGame.title}</h2>
+              <p style={gameDescriptionStyle}>{activeGame.description}</p>
+            </div>
+            <div style={gameAreaStyle}>{activeGame.component}</div>
+          </section>
+        ) : (
+          <section style={listContainerStyle}>
+            <h2 style={listTitleStyle}>Featured Games</h2>
+            <ul style={listStyle}>
+              {games.map((game) => (
+                <li key={game.title} style={listItemStyle}>
+                  <button
+                    onClick={() => setActiveGame(game)}
+                    style={gameButtonStyle}
+                    type="button"
+                  >
+                    <div>
+                      <h3 style={gameButtonTitleStyle}>{game.title}</h3>
+                      <p style={gameDescriptionStyle}>{game.description}</p>
+                    </div>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </section>
+        )}
         <p style={footerStyle}>Stay tuned — new vibes are on their way.</p>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- introduce an active game state on the arcade landing page so the main view lists games and opens the chosen title on click
- add styled buttons and containers to present the game list and active game consistently with the existing synthwave aesthetic

## Testing
- yarn build

------
https://chatgpt.com/codex/tasks/task_e_68cdd736a1f08324a0f0495bfb0af186